### PR TITLE
Fix sensitive data leak in auth middleware across all packages

### DIFF
--- a/packages/adonis/src/plugins/v1/hooks.ts
+++ b/packages/adonis/src/plugins/v1/hooks.ts
@@ -15,7 +15,7 @@ export async function assertAuthorizationSchemeValidMiddleware(
 		context.response
 			.status(401)
 			.send(
-				`Apple Schema validation for Authorization header failed. Received: '${authorization}'`,
+				"Apple Schema validation for Authorization header failed.",
 			);
 		return;
 	}
@@ -37,9 +37,6 @@ export function assertTokenValidMiddleware(
 		const token = getAuthorizationToken(authorization);
 
 		if (!(await verifyToken(token))) {
-			console.warn(
-				`Authorization token validation failed. Received: ${authorization}`,
-			);
 			context.response.status(401).send({});
 			return;
 		}

--- a/packages/express/src/middlewares/v1/hooks.ts
+++ b/packages/express/src/middlewares/v1/hooks.ts
@@ -15,7 +15,7 @@ export function assertAuthorizationSchemeValid(
 		response
 			.status(401)
 			.send(
-				`Apple Schema validation for Authorization header failed. Received: '${authorization}'`,
+				"Apple Schema validation for Authorization header failed.",
 			);
 		return;
 	}
@@ -41,9 +41,6 @@ export function assertTokenValid(
 		const token = getAuthorizationToken(authorization);
 
 		if (!(await verifyToken(token))) {
-			console.warn(
-				`Authorization token validation failed. Received: ${authorization}`,
-			);
 			response.status(401).send();
 			return;
 		}

--- a/packages/fastify/src/plugins/v1/hooks.ts
+++ b/packages/fastify/src/plugins/v1/hooks.ts
@@ -18,7 +18,7 @@ export function checkAuthorizationSchemeValidationHook(
 	const { authorization = "" } = request.headers;
 
 	if (!isAuthorizationSchemeValid(authorization)) {
-		request.log.info({ authorization }, "Apple Schema validation failed");
+		request.log.info("Apple Schema validation for Authorization header failed.");
 		reply.code(401).send();
 		return;
 	}

--- a/packages/hono/src/middlewares/v1/hooks.ts
+++ b/packages/hono/src/middlewares/v1/hooks.ts
@@ -14,7 +14,7 @@ export async function assertAuthorizationSchemeValid(
 	if (!isAuthorizationSchemeValid(authorization)) {
 		context.status(401);
 		return context.json({
-			message: `Apple Schema validation for Authorization header failed. Received: '${authorization}'.`,
+			message: "Apple Schema validation for Authorization header failed.",
 		});
 	}
 
@@ -34,12 +34,9 @@ export function assertTokenValid(
 		const token = getAuthorizationToken(authorization);
 
 		if (!(await verifyToken(token))) {
-			console.warn(
-				`Authorization token validation failed. Received: ${authorization}`,
-			);
 			context.status(401);
 			return context.json({
-				message: `Authorization token validation failed. Received: ${authorization}`,
+				message: "Authorization token validation failed.",
 			});
 		}
 


### PR DESCRIPTION
Remove console.warn/log statements that logged full Authorization headers (including Bearer tokens) to stdout. Also stop echoing raw Authorization header values back to clients in HTTP response bodies.

Affected packages: hono, express, adonis, fastify.